### PR TITLE
projects/S905: enable fq_codel in the linux kernel

### DIFF
--- a/projects/S905/linux/linux.aarch64.conf
+++ b/projects/S905/linux/linux.aarch64.conf
@@ -686,7 +686,51 @@ CONFIG_LLC=m
 # CONFIG_PHONET is not set
 # CONFIG_IEEE802154 is not set
 CONFIG_6LOWPAN_IPHC=m
-# CONFIG_NET_SCHED is not set
+CONFIG_NET_SCHED=y
+
+#
+# Queueing/Scheduling
+#
+# CONFIG_NET_SCH_CBQ is not set
+# CONFIG_NET_SCH_HTB is not set
+# CONFIG_NET_SCH_HFSC is not set
+# CONFIG_NET_SCH_PRIO is not set
+# CONFIG_NET_SCH_MULTIQ is not set
+# CONFIG_NET_SCH_RED is not set
+# CONFIG_NET_SCH_SFB is not set
+# CONFIG_NET_SCH_SFQ is not set
+# CONFIG_NET_SCH_TEQL is not set
+# CONFIG_NET_SCH_TBF is not set
+# CONFIG_NET_SCH_GRED is not set
+# CONFIG_NET_SCH_DSMARK is not set
+# CONFIG_NET_SCH_NETEM is not set
+# CONFIG_NET_SCH_DRR is not set
+# CONFIG_NET_SCH_MQPRIO is not set
+# CONFIG_NET_SCH_CHOKE is not set
+# CONFIG_NET_SCH_QFQ is not set
+# CONFIG_NET_SCH_CODEL is not set
+CONFIG_NET_SCH_FQ_CODEL=y
+# CONFIG_NET_SCH_FQ is not set
+# CONFIG_NET_SCH_HHF is not set
+# CONFIG_NET_SCH_PIE is not set
+# CONFIG_NET_SCH_PLUG is not set
+
+#
+# Classification
+#
+# CONFIG_NET_CLS_BASIC is not set
+# CONFIG_NET_CLS_TCINDEX is not set
+# CONFIG_NET_CLS_ROUTE4 is not set
+# CONFIG_NET_CLS_FW is not set
+# CONFIG_NET_CLS_U32 is not set
+# CONFIG_NET_CLS_RSVP is not set
+# CONFIG_NET_CLS_RSVP6 is not set
+# CONFIG_NET_CLS_FLOW is not set
+# CONFIG_NET_CLS_CGROUP is not set
+# CONFIG_NET_CLS_BPF is not set
+# CONFIG_NET_EMATCH is not set
+# CONFIG_NET_CLS_ACT is not set
+CONFIG_NET_SCH_FIFO=y
 # CONFIG_DCB is not set
 CONFIG_DNS_RESOLVER=y
 # CONFIG_BATMAN_ADV is not set


### PR DESCRIPTION
This qdisc aims to eliminate bufferbloat and as a side effect improves latency during heavy network load. The most notable effect will be a slightly more responsive ssh session during large downloads.

Systemd will autoselect fq_codel when it's available:

```
m8s:~ # ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 4096 qdisc noqueue
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP8000> mtu 1500 qdisc fq_codel qlen 1000
    link/ether 82:cd:fa:1b:03:1d brd ff:ff:ff:ff:ff:ff
    inet 172.20.0.166/24 brd 172.20.0.255 scope global eth0
       valid_lft forever preferred_lft forever
3: wlan0: <NO-CARRIER,BROADCAST,MULTICAST,UP,LOWER_UP8000> mtu 1500 qdisc fq_codel qlen 1000
    link/ether 44:2c:05:43:8c:eb brd ff:ff:ff:ff:ff:ff
    inet6 fe80::462c:5ff:fe43:8ceb/64 scope link
       valid_lft forever preferred_lft forever
```

On the S905X 100Mbit link it shows no negative effects:

```
m8s:~ # curl http://beast.local/koen/largefile.mkv --http1.1  > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  7 14.9G    7 1105M    0     0  11.1M      0  0:22:50  0:01:38  0:21:12 11.2M
```

See https://en.wikipedia.org/wiki/CoDel for more information on CODEL

Signed-off-by: Koen Kooi koen.kooi@linaro.org
