### PR TITLE
Quick fix for invalid cp

### DIFF
--- a/projects/S905/filesystem/usr/share/bootloader/update.sh
+++ b/projects/S905/filesystem/usr/share/bootloader/update.sh
@@ -37,13 +37,13 @@ for arg in $(cat /proc/cmdline); do
           ;;
       esac
 
-      if [ -f $UPDATE_DTB_IMG ] ; then
+      if [ -f "$UPDATE_DTB_IMG" ] ; then
         UPDATE_DTB_SOURCE="$UPDATE_DTB_IMG"
-      elif [ -f $UPDATE_DTB ] ; then
+      elif [ -f "$UPDATE_DTB" ] ; then
         UPDATE_DTB_SOURCE="$UPDATE_DTB"
       fi
 
-      if [ -f $UPDATE_DTB_SOURCE ] ; then
+      if [ -f "$UPDATE_DTB_SOURCE" ] ; then
         echo "Updating device tree from $UPDATE_DTB_SOURCE..."
         case $boot in
           /dev/system)


### PR DESCRIPTION
Maybe tweak **ls -1 "$UPDATE_DIR"/*.dtb 2>/dev/null | head -n 1** is a better solution.
I'm not an expert in bash but this quick and dirty fix  works for me
Not was tested on a real build, just on my console.