### PR TITLE
libass: update to 0.13.4

### DIFF
--- a/packages/multimedia/libass/package.mk
+++ b/packages/multimedia/libass/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libass"
-PKG_VERSION="0.13.2"
+PKG_VERSION="0.13.4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"


### PR DESCRIPTION
Based on the comments from https://github.com/LibreELEC/LibreELEC.tv/pull/918 I think that you need to cherry-pick a99d8579d12f7bfbd75ac771b54b74223e335692 to improve the backport done at https://github.com/kszaq/LibreELEC.tv/blob/7c77820b449dd15dede2f9768cb60c2f03cce012/packages/mediacenter/kodi/patches/kodi-999.28-PR10873.patch

Fell free to just cherry-pick and close this PR.