### PR TITLE
projects/S905: set same mode during switch

### DIFF
--- a/projects/S905/patches/kodi/le-s905-002-EGLNativeTypeAmlogic-Set-the-same-mode-as-curr.patch
+++ b/projects/S905/patches/kodi/le-s905-002-EGLNativeTypeAmlogic-Set-the-same-mode-as-curr.patch
@@ -1,0 +1,32 @@
+From 75ce3df42880e38ee750fb30ee607d86ab001caa Mon Sep 17 00:00:00 2001
+From: RealJohnGalt <johngalt@fake.mail>
+Date: Fri, 2 Jun 2017 00:07:08 -0700
+Subject: [PATCH] EGLNativeTypeAmlogic: Set the same mode as current
+
+We must set a mode to pass colorspace changes.
+---
+ xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp | 8 +-------
+ 1 file changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+index 0af8b48..765fd4f 100644
+--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
++++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.cpp
+@@ -152,13 +152,7 @@ bool CEGLNativeTypeAmlogic::SetNativeResolution(const RESOLUTION_INFO &res)
+   }
+ #endif
+ 
+-  // Don't set the same mode as current
+-  RESOLUTION_INFO current_resolution;
+-  GetNativeResolution(&current_resolution);
+-  if (current_resolution.strId != res.strId ||
+-    current_resolution.fRefreshRate != res.fRefreshRate)
+-    result = SetDisplayResolution(res);
+-
++  result = SetDisplayResolution(res);
+   DealWithScale(res);
+ 
+   return result;
+-- 
+2.13.0
+


### PR DESCRIPTION
We must set display mode to pass colorspace. For instance, if GUI is at 2160@50, and a bt2020 video is 2160@25, the display will still reset 2160@50 so colorspace is passed. Without this patch because of no new mode change, the colorspace isn't passed.