### PR TITLE
projects/S905: update.sh: fix boot failure if space in dtb filename

### DIFF
--- a/projects/S905/filesystem/usr/share/bootloader/update.sh
+++ b/projects/S905/filesystem/usr/share/bootloader/update.sh
@@ -68,11 +68,11 @@ for arg in $(cat /proc/cmdline); do
         case $boot in
           /dev/system)
             dd if=/dev/zero of=/dev/dtb bs=256k count=1 status=none
-            dd if=$UPDATE_DTB_SOURCE of=/dev/dtb bs=256k status=none
+            dd if="$UPDATE_DTB_SOURCE" of=/dev/dtb bs=256k status=none
             ;;
           /dev/mmc*|LABEL=*)
             mount -o rw,remount $BOOT_ROOT
-            cp -f $UPDATE_DTB_SOURCE "$BOOT_ROOT/dtb.img"
+            cp -f "$UPDATE_DTB_SOURCE" "$BOOT_ROOT/dtb.img"
             ;;
         esac
       fi


### PR DESCRIPTION
If the dtb placed in /storage/.update has spaces in filename, dd command fails leaving system without device tree as it has been previously erased