### PR TITLE
fix for meson-ir - adds timer to send signal end

### DIFF
--- a/packages/linux-drivers/media_build/patches/media_build-02-add-to-backports.patch
+++ b/packages/linux-drivers/media_build/patches/media_build-02-add-to-backports.patch
@@ -1,6 +1,6 @@
 --- a/backports/backports.txt
 +++ b/backports/backports.txt
-@@ -25,6 +25,23 @@
+@@ -25,6 +25,24 @@
  add pr_fmt.patch
  add debug.patch
  add drx39xxj.patch
@@ -13,6 +13,7 @@
 +add linux-220-Xbox-One-DVB-T2-stick-support.patch
 +add linux-249-gpioplug.patch
 +add linux-250-meson-ir.patch
++add linux-251-meson-ir-timeout.patch
 +add linux-253-wetek-dvb.patch
 +add linux-260-fix-for-kernel-4.11.patch
 +add linux-261-fix-for-kernel-4.11-dibusb-license.patch

--- a/packages/linux-drivers/media_build/sources/backports/linux-251-meson-ir-timeout.patch
+++ b/packages/linux-drivers/media_build/sources/backports/linux-251-meson-ir-timeout.patch
@@ -1,0 +1,64 @@
+diff -Naur a/drivers/media/rc/meson-ir.c b/drivers/media/rc/meson-ir.c
+--- a/drivers/media/rc/meson-ir.c	2018-02-07 11:47:26.189953382 +0100
++++ a/drivers/media/rc/meson-ir.c	2018-02-07 11:56:36.794298942 +0100
+@@ -71,6 +71,7 @@
+ 	struct rc_dev	*rc;
+ 	int		irq;
+ 	spinlock_t	lock;
++	struct timer_list flush_timer;
+ };
+ 
+ static void meson_ir_set_mask(struct meson_ir *ir, unsigned int reg,
+@@ -101,11 +102,25 @@
+ 	ir_raw_event_store(ir->rc, &rawir);
+ 	ir_raw_event_handle(ir->rc);
+ 
++	mod_timer(&ir->flush_timer,
++		jiffies + nsecs_to_jiffies(ir->rc->timeout));
++
+ 	spin_unlock(&ir->lock);
+ 
+ 	return IRQ_HANDLED;
+ }
+ 
++static void flush_timer(unsigned long arg)
++{
++	struct meson_ir *ir = (struct meson_ir *)arg;
++	DEFINE_IR_RAW_EVENT(rawir);
++
++	rawir.timeout = true;
++	rawir.duration = ir->rc->timeout;
++	ir_raw_event_store(ir->rc, &rawir);
++	ir_raw_event_handle(ir->rc);
++}
++
+ static int meson_ir_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -149,7 +164,7 @@
+ 	ir->rc->driver_type = RC_DRIVER_IR_RAW;
+ 	ir->rc->allowed_protos = RC_BIT_ALL;
+ 	ir->rc->rx_resolution = US_TO_NS(MESON_TRATE);
+-	ir->rc->timeout = MS_TO_NS(200);
++	ir->rc->timeout = MS_TO_NS(50);
+ 	ir->rc->driver_name = DRIVER_NAME;
+ 
+ 	spin_lock_init(&ir->lock);
+@@ -170,6 +185,8 @@
+ 		}
+ 	}
+ 
++	setup_timer(&ir->flush_timer, flush_timer, (unsigned long) ir);
++
+ 	ret = devm_request_irq(dev, ir->irq, meson_ir_irq, 0, "ir-meson", ir);
+ 	if (ret) {
+ 		dev_err(dev, "failed to request irq\n");
+@@ -218,6 +235,8 @@
+ 	meson_ir_set_mask(ir, IR_DEC_REG1, REG1_ENABLE, 0);
+ 	spin_unlock_irqrestore(&ir->lock, flags);
+ 
++	del_timer_sync(&ir->flush_timer);
++
+ 	rc_unregister_device(ir->rc);
+ 
+ 	return 0;


### PR DESCRIPTION
Cherrypicked from https://github.com/LibreELEC/linux-amlogic/commit/320e39662e99656b9e09ad55fbfe3764ffb9eaec

Signed-off-by: root <github@danman.eu>